### PR TITLE
Remove needless description for us

### DIFF
--- a/makerelease.sh
+++ b/makerelease.sh
@@ -127,19 +127,11 @@ Binaries for the following compilers are included
 
  - Visual C++ 2022 (built with 17.2.0 preview 2.1)
  - Visual C++ 2019 (built with 16.11.11)
- - Visual C++ 2017 (built with 15.9.45)
- - Visual C++ 2015 (built with 14.0.25431.01)
- - Visual C++ 2013 (built with 12.0.40629.00)
- - Visual C++ 2012 (built with 11.0.61219.00)
- - Visual C++ 2010 (built with 10.0.30319.1)
  - MinGW-w64 (built with GCC 8.1.0)
  - MinGW (built with GCC 9.2.0)
 
 
 ## Binaries for Visual C++
-
-All binaries for Visual C++ 2017 and earlier are compatible with Windows XP, but
-this is not supported by Visual C++ 2019.
 
 ### GLFW as a DLL
 
@@ -201,17 +193,10 @@ Binaries for the following compilers are included
 
  - Visual C++ 2022 (built with 17.2.0 preview 2.1)
  - Visual C++ 2019 (built with 16.11.11)
- - Visual C++ 2017 (built with 15.9.45)
- - Visual C++ 2015 (built with 14.0.25431.01)
- - Visual C++ 2013 (built with 12.0.40629.00)
- - Visual C++ 2012 (built with 11.0.61219.00)
  - MinGW-w64 (built with GCC 8.1.0)
 
 
 ## Binaries for Visual C++
-
-All binaries for Visual C++ 2017 and earlier are compatible with Windows XP, but
-this is not supported by Visual C++ 2019.
 
 ### GLFW as a DLL
 


### PR DESCRIPTION
This fixes the README of WIN32 and WIN64.